### PR TITLE
feat(contracts): Fix precompile call

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -50,7 +50,7 @@ const config: HardhatUserConfig = {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 100,
+            runs: 50,
           },
         },
       },

--- a/ignition/modules/QPDeploy.ts
+++ b/ignition/modules/QPDeploy.ts
@@ -116,6 +116,7 @@ const deployModule = buildModule("DeployModule", (m) => {
     
 	m.call(minerMgr, "updateBaseToken", [conf.FRM[currentChainId!]])
 	m.call(ledgerMgr, "updateLedger", [poc], { id: "UpdateLedgerOnLedgerMgr"})
+    m.call(staking, "setAdmin", [gateway])
 
     const settings  = [
         {


### PR DESCRIPTION
3 small additions:
- `.call` to precompile instead of calling with ABI
- Set lower optimization runs in compiler; contracts are getting too big
- Set staking contract's admin to be gateway